### PR TITLE
Ignore linewidth warning during lint

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = H101, H202
+ignore = H101, H202, E501
 exclude =
     .git,
     __pycache__,


### PR DESCRIPTION
Ignores linting warnings like this

> src/visualization/visualize.py:39:80: E501 line too long (98 > 79 characters)

Let's decide ourselves how long our lines will be :fist_raised: 